### PR TITLE
fix: register deadline for tree values when ttl is informed

### DIFF
--- a/src/types/key-tree-cache-storage.ts
+++ b/src/types/key-tree-cache-storage.ts
@@ -1,4 +1,5 @@
 export interface KeyTreeCacheStorage<R = string> {
 	get(key: string): Promise<R | undefined> | R | undefined;
 	set(key: string, value: R, ttl?: number): Promise<unknown> | unknown;
+	getCurrentTtl(key: string): Promise<number | undefined> | number | undefined;
 }

--- a/src/types/tree-type.ts
+++ b/src/types/tree-type.ts
@@ -6,11 +6,13 @@ export type TreeChildren<T> = {
 export enum TreeKeys {
 	children = 'c',
 	value = 'v',
+	deadline = 'd',
 }
 
 export interface Tree<T> {
 	[TreeKeys.children]?: TreeChildren<T>;
 	[TreeKeys.value]?: T;
+	[TreeKeys.deadline]?: number;
 }
 
 export interface Step<T> {


### PR DESCRIPTION
custom ttl weren't work as expected when values must be saved on tree nodes, as the storage ttl was the only expiration control.

Now, the deadline for each saved node is saved according to the informed ttl (when it is informed)
Also, getCurrentTtl is specified on the storage interface so the library can elect between the current ttl left and the custom one informed, to guarantee that the key will be kept at least for the duration of the latest key to be expired