### PR TITLE
feat: creating memoizer option

### DIFF
--- a/src/types/key-tree-cache-options.ts
+++ b/src/types/key-tree-cache-options.ts
@@ -9,9 +9,15 @@ export interface Serializer<A, B> {
 	deserialize(b: B): A;
 }
 
+export interface Memoizer {
+	get<B>(key: string): B | undefined;
+	set<B>(key: string, value: B): unknown;
+}
+
 export interface KeyTreeCacheOptions<T, R = string> {
 	keyLevelNodes: number;
 	valueSerializer?: Serializer<T, R>;
 	treeSerializer?: Serializer<Tree<R>, R>;
 	semaphore?: Semaphore;
+	memoizer?: Memoizer;
 }


### PR DESCRIPTION
The memoizer options will allow the lib user to specify a memoizer implementation, so subsequent reads of the same storage key and its parsing won't need to be done twice.
The memoizer scope must be controlled totally by the caller, and we recommend to do it using some map stored into a async hook sotrage, so it can be done by request.