### PR TITLE
feat: implementing deserialize-whole-tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
+        "clone": "^2.1.2",
         "typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@codibre/confs": "^1.1.2",
         "@nestjs/cli": "^10.1.17",
+        "@types/clone": "^2.1.3",
         "@types/eslint": "^8.44.2",
         "@types/jest": "^29.5.4",
         "@typescript-eslint/eslint-plugin": "^6.6.0",
@@ -2277,6 +2279,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/clone": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.3.tgz",
+      "integrity": "sha512-DxFaNYaIUXW1OSRCVCC1UHoLcvk6bVJ0v9VvUaZ6kR5zK8/QazXlOThgdvnK0Xpa4sBq+b/Yoq/mnNn383hVRw==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -3630,10 +3638,9 @@
       }
     },
     "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "engines": {
         "node": ">=0.8"
       }
@@ -4006,6 +4013,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -12020,6 +12036,12 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/clone": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.3.tgz",
+      "integrity": "sha512-DxFaNYaIUXW1OSRCVCC1UHoLcvk6bVJ0v9VvUaZ6kR5zK8/QazXlOThgdvnK0Xpa4sBq+b/Yoq/mnNn383hVRw==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.44.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
@@ -13013,10 +13035,9 @@
       }
     },
     "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "co": {
       "version": "4.6.0",
@@ -13272,6 +13293,14 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+          "dev": true
+        }
       }
     },
     "define-lazy-prop": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@codibre/confs": "^1.1.2",
     "@nestjs/cli": "^10.1.17",
+    "@types/clone": "^2.1.3",
     "@types/eslint": "^8.44.2",
     "@types/jest": "^29.5.4",
     "@typescript-eslint/eslint-plugin": "^6.6.0",
@@ -98,6 +99,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "clone": "^2.1.2",
     "typed-emitter": "^2.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 export * from './types';
 export * from './tree-key-cache';
-export * from './utils/graphs/build-key';
+export {
+	buildKey,
+	treePreOrderBreadthFirstSearch,
+	treePreOrderDepthFirstSearch,
+} from './utils/graphs';
+export { deserializeWholeTree, EmptyTree, TreeError } from './utils';

--- a/src/utils/deserialize-whole-tree.ts
+++ b/src/utils/deserialize-whole-tree.ts
@@ -1,0 +1,57 @@
+import { Serializer, Tree, TreeKeys } from '../types';
+import { treePreOrderDepthFirstSearch } from './graphs';
+import { valueSymbol } from './graphs/tree-pre-order-traversal';
+import { isUndefined } from './is-undefined';
+
+export class TreeError extends Error {}
+export class EmptyTree extends Error {
+	constructor() {
+		super('Empty tree');
+	}
+}
+
+export function deserializeWholeTree<T, R = string>(
+	data: R,
+	treeSerializer: Serializer<Tree<R>, R>,
+	valueSerializer: Serializer<T, R>,
+) {
+	const tree = treeSerializer.deserialize(data);
+	if (
+		isUndefined(tree[TreeKeys.children]) &&
+		isUndefined(tree[TreeKeys.value])
+	) {
+		throw new EmptyTree();
+	}
+	const rootValue = tree[TreeKeys.value];
+	const newTree: Tree<T> = {
+		[TreeKeys.value]: rootValue
+			? valueSerializer.deserialize(rootValue)
+			: undefined,
+	};
+	const stack: Tree<T>[] = [newTree];
+	let currentLevel = 0;
+
+	for (const node of treePreOrderDepthFirstSearch(tree)) {
+		currentLevel++;
+		if (currentLevel < node.level) {
+			throw new TreeError('Path lost');
+		}
+		while (currentLevel > node.level) {
+			if (stack.length === 0) {
+				throw new TreeError('Stack lost');
+			}
+			stack.pop();
+			currentLevel--;
+		}
+		const currentNode = stack[stack.length - 1] as Tree<T>;
+		const map = (currentNode[TreeKeys.children] ??= {});
+		const current = (map[node.key] ??= {});
+		const value = node[valueSymbol];
+		if (!isUndefined(value)) {
+			current[TreeKeys.value] = valueSerializer.deserialize(value);
+		}
+		stack.push(current);
+	}
+
+	return newTree;
+}

--- a/src/utils/deserialize-whole-tree.ts
+++ b/src/utils/deserialize-whole-tree.ts
@@ -10,6 +10,14 @@ export class EmptyTree extends Error {
 	}
 }
 
+/**
+ * Given a in memory data of a tree, deserializeWholeTree will perform a tree deserialization and then the deserialization of each value on the tree, returning the completly deserialized tree.
+ * This is useful, for example, if you want to create a function to print a tree value for debug purposes, for example.
+ * @param data the serialized data of a tree
+ * @param treeSerializer the tree serializer
+ * @param valueSerializer the value serializer
+ * @returns the completely deserialized tree
+ */
 export function deserializeWholeTree<T, R = string>(
 	data: R,
 	treeSerializer: Serializer<Tree<R>, R>,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './deserialize-whole-tree';
 export * from './dont-wait';
 export * from './get-chained-key';
 export * from './get-key';

--- a/test/unit/utils/deserialize-whole-tree.spec.ts
+++ b/test/unit/utils/deserialize-whole-tree.spec.ts
@@ -1,0 +1,92 @@
+import { Tree, TreeKeys, deserializeWholeTree, EmptyTree } from '../../../src';
+import clone from 'clone';
+
+function serializeRecursive(tree: Tree<unknown>) {
+	for (const k in tree) {
+		if (k in tree) {
+			if (k === TreeKeys.value) {
+				tree[k] = JSON.stringify(tree[k]);
+			} else if (k === TreeKeys.children) {
+				const children = tree[k];
+				for (const k2 in children) {
+					if (k2 in children) {
+						const item = children[k2];
+						if (item) {
+							serializeRecursive(item);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+function serialize(tree: Tree<unknown>) {
+	const clonedTree = clone(tree);
+	serializeRecursive(clonedTree);
+	return JSON.stringify(clonedTree);
+}
+
+const serializer = {
+	serialize: JSON.stringify.bind(JSON),
+	deserialize: JSON.parse.bind(JSON),
+};
+
+describe(deserializeWholeTree.name, () => {
+	it('should deserialize tree and values', () => {
+		const tree = {
+			[TreeKeys.value]: '123',
+			[TreeKeys.children]: {
+				a: {
+					[TreeKeys.value]: 456,
+				},
+				b: {
+					[TreeKeys.value]: { s: '78', n: 9 },
+				},
+				c: {
+					[TreeKeys.value]: true,
+					[TreeKeys.children]: {
+						d: {
+							[TreeKeys.value]: { t: true },
+							[TreeKeys.children]: {
+								d2: {
+									[TreeKeys.value]: 5,
+									[TreeKeys.children]: {
+										d3: {
+											[TreeKeys.children]: {
+												d4: {
+													[TreeKeys.value]: 7,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				d: {
+					[TreeKeys.value]: false,
+				},
+			},
+		};
+
+		const serializedTree = serialize(tree);
+
+		const result = deserializeWholeTree(serializedTree, serializer, serializer);
+
+		expect(result).toEqual(tree);
+	});
+
+	it('should throw an error for an empty tree', () => {
+		let error: any;
+
+		try {
+			deserializeWholeTree(JSON.stringify({}), serializer, serializer);
+		} catch (err) {
+			error = err;
+		}
+
+		expect(error).toBeInstanceOf(EmptyTree);
+	});
+});


### PR DESCRIPTION
Given a in memory data of a tree, deserializeWholeTree will perform a tree deserialization and then the deserialization of each value on the tree, returning the completly deserialized tree.
This is useful, for example, if you want to create a function to print a tree value for debug purposes, for example.