### PR TITLE
fix: ignoring value during set iteration when it is expired

### DIFF
--- a/test/unit/tree-key-cache.spec.ts
+++ b/test/unit/tree-key-cache.spec.ts
@@ -585,6 +585,66 @@ describe(TreeKeyCache.name, () => {
 			expect(acquire).toHaveCallsLike(['a'], ['a:b'], ['a:b:c'], ['a:b:c:d']);
 			expect(release).toHaveCallsLike([], [], [], []);
 		});
+
+		it('should set the path when some node in the tree level is expired', async () => {
+			const now = Date.now();
+			map.set(
+				'a:b:c:d',
+				JSON.stringify({
+					[TreeKeys.value]: '{"value":40}',
+					[TreeKeys.children]: {
+						e: {
+							[TreeKeys.value]: '{"value":50}',
+							[TreeKeys.deadline]: now - 10,
+							[TreeKeys.children]: {
+								f: { [TreeKeys.value]: '{"value":60}' },
+							},
+						},
+					},
+				} as Tree<string>),
+			);
+
+			const iterable = target.deepTreeSet(
+				['a', 'b', 'c', 'd', 'e', 'f'],
+				() => ({ value: 0 }),
+			);
+			let first = true;
+
+			for await (const item of iterable) {
+				if (item.value && item.level >= 4) {
+					if (first) first = false;
+					else {
+						item.value.value = 99;
+					}
+				}
+			}
+
+			expect(
+				Array.from(map.entries()).sort((a, b) => (b[0] > a[0] ? 1 : -1)),
+			).toEqual(
+				[
+					[
+						'a:b:c:d',
+						JSON.stringify({
+							[TreeKeys.value]: '{"value":40}',
+							[TreeKeys.children]: {
+								e: {
+									[TreeKeys.value]: '{"value":99}',
+									[TreeKeys.children]: {
+										f: { [TreeKeys.value]: '{"value":99}' },
+									},
+								},
+							},
+						} as Tree<string>),
+					],
+					['a:b:c', '{"value":30}'],
+					['a:b', '{"value":20}'],
+					['a', '{"value":10}'],
+				].sort((a, b) => (b[0]! > a[0]! ? 1 : -1)),
+			);
+			expect(acquire).toHaveCallsLike(['a'], ['a:b'], ['a:b:c'], ['a:b:c:d']);
+			expect(release).toHaveCallsLike([], [], [], []);
+		});
 	});
 
 	describe(proto.setNode.name, () => {


### PR DESCRIPTION
If the expired value is not ignored during a set iteration, it will be revalidated and the ttl renewed