### PR TITLE
feat: refactoring pre-order and implementing post order traversal methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
+        "@codibre/fluent-iterable": "^1.32.0",
         "clone": "^2.1.2",
         "typed-emitter": "^2.1.0"
       },
@@ -815,6 +816,31 @@
         "ts-node": "*",
         "typescript": "*"
       }
+    },
+    "node_modules/@codibre/fluent-iterable": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@codibre/fluent-iterable/-/fluent-iterable-1.32.0.tgz",
+      "integrity": "sha512-Z1zW0mmMEkI+9DxI//ih/k/N/CqGTfvJ78drSMpNUWifZUS/AJrTPunfZ1lA1sFcDyUM6vRWJb4Sd8JH0rRjmA==",
+      "dependencies": {
+        "augmentative-iterable": "^1.5.8",
+        "typed-emitter": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "for-emit-of": "^1.3.3"
+      },
+      "peerDependenciesMeta": {
+        "for-emit-of": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@codibre/fluent-iterable/node_modules/typed-emitter": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+      "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -3022,6 +3048,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/augmentative-iterable": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/augmentative-iterable/-/augmentative-iterable-1.5.11.tgz",
+      "integrity": "sha512-2lQJmXv+4FUnldQ1uMw1QiRFl/2jdALbEYK8l5pdvfbX5aN2xUfyfEm5xj8Eva/i5nUN7TQzxU7UBaaNjKSvXA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-jest": {
@@ -10933,6 +10967,22 @@
         "tsconfig-paths": ">=3.9.0"
       }
     },
+    "@codibre/fluent-iterable": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@codibre/fluent-iterable/-/fluent-iterable-1.32.0.tgz",
+      "integrity": "sha512-Z1zW0mmMEkI+9DxI//ih/k/N/CqGTfvJ78drSMpNUWifZUS/AJrTPunfZ1lA1sFcDyUM6vRWJb4Sd8JH0rRjmA==",
+      "requires": {
+        "augmentative-iterable": "^1.5.8",
+        "typed-emitter": "^1.4.0"
+      },
+      "dependencies": {
+        "typed-emitter": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+          "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg=="
+        }
+      }
+    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -12621,6 +12671,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
+    },
+    "augmentative-iterable": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/augmentative-iterable/-/augmentative-iterable-1.5.11.tgz",
+      "integrity": "sha512-2lQJmXv+4FUnldQ1uMw1QiRFl/2jdALbEYK8l5pdvfbX5aN2xUfyfEm5xj8Eva/i5nUN7TQzxU7UBaaNjKSvXA=="
     },
     "babel-jest": {
       "version": "29.6.4",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "@codibre/fluent-iterable": "^1.32.0",
     "clone": "^2.1.2",
     "typed-emitter": "^2.1.0"
   }

--- a/src/utils/graphs/async/async-tree-post-order-breadth-first-search.ts
+++ b/src/utils/graphs/async/async-tree-post-order-breadth-first-search.ts
@@ -1,0 +1,21 @@
+import { AsyncTree, ChainedObject } from 'src/types';
+import { AsyncQueue } from './aync-queue';
+import { asyncTreePostOrderTraversal } from './async-tree-post-order-traversal';
+
+/**
+ * Implementation of async pre order traversal, breadth first search algorithm for Trees
+ * @param tree The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export function asyncTreePostOrderBreadthFirstSearch<T>(
+	tree: AsyncTree<T>,
+	parentRef: ChainedObject | undefined,
+) {
+	return asyncTreePostOrderTraversal(
+		tree,
+		new AsyncQueue(),
+		parentRef,
+		undefined,
+	);
+}

--- a/src/utils/graphs/async/async-tree-post-order-depth-first-search.ts
+++ b/src/utils/graphs/async/async-tree-post-order-depth-first-search.ts
@@ -1,0 +1,21 @@
+import { AsyncTree, ChainedObject } from 'src/types';
+import { AsyncStack } from './aync-stack';
+import { asyncTreePostOrderTraversal } from './async-tree-post-order-traversal';
+
+/**
+ * Implementation of async pre order traversal, depth first search algorithm for Trees
+ * @param tree The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export function asyncTreePostOrderDepthFirstSearch<T>(
+	tree: AsyncTree<T>,
+	parentRef: ChainedObject | undefined,
+) {
+	return asyncTreePostOrderTraversal(
+		tree,
+		new AsyncStack(),
+		parentRef,
+		undefined,
+	);
+}

--- a/src/utils/graphs/async/async-tree-post-order-traversal.ts
+++ b/src/utils/graphs/async/async-tree-post-order-traversal.ts
@@ -1,0 +1,55 @@
+import { AsyncTree, ChainedObject, Tree, TreeKeys } from 'src/types';
+import { createTraversalItem } from '../create-traversal-item';
+import { StorageTraversalItem } from '../graph-types';
+import { AsyncSimpleList } from './async-struct-helper';
+
+/**
+ * Implementation of pre order traversal for Trees
+ * @param treeRef The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export async function* asyncTreePostOrderTraversal<T>(
+	treeRef: AsyncTree<T> | Tree<T>,
+	list: AsyncSimpleList<
+		[AsyncTree<T> | Tree<T>, string | undefined, ChainedObject | undefined]
+	>,
+	parentRef: ChainedObject | undefined,
+	key: string | undefined,
+): AsyncIterable<StorageTraversalItem<T>> {
+	const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
+	const level = parentRef?.level ?? 0;
+	let node: StorageTraversalItem<T> | undefined;
+	if (key !== undefined) {
+		node = createTraversalItem(key, level + 1, parentRef, treeRef, value);
+	}
+	if (typeof children === 'function') {
+		for await (const [nextKey, nextValue] of children.call(treeRef)) {
+			if (nextValue !== undefined) {
+				yield* asyncTreePostOrderTraversal<T>(
+					nextValue,
+					list,
+					node ?? parentRef,
+					nextKey,
+				);
+			}
+		}
+	} else if (children) {
+		// eslint-disable-next-line guard-for-in
+		for (const nextKey in children) {
+			const nextTree = children[nextKey];
+			if (nextTree) {
+				await list.push([nextTree, nextKey, node]);
+				yield* asyncTreePostOrderTraversal<T>(
+					nextTree,
+					list,
+					node ?? parentRef,
+					nextKey,
+				);
+			}
+		}
+	}
+	if (node) {
+		yield node;
+	}
+}

--- a/src/utils/graphs/async/index.ts
+++ b/src/utils/graphs/async/index.ts
@@ -1,2 +1,4 @@
+export * from './async-tree-post-order-breadth-first-search';
+export * from './async-tree-post-order-depth-first-search';
 export * from './async-tree-pre-order-breadth-first-search';
 export * from './async-tree-pre-order-depth-first-search';

--- a/src/utils/graphs/index.ts
+++ b/src/utils/graphs/index.ts
@@ -1,4 +1,6 @@
 export * from './build-key';
 export * from './create-traversal-item';
+export * from './tree-post-order-breadth-first-search';
+export * from './tree-post-order-depth-first-search';
 export * from './tree-pre-order-breadth-first-search';
 export * from './tree-pre-order-depth-first-search';

--- a/src/utils/graphs/tree-post-order-breadth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-breadth-first-search.ts
@@ -12,5 +12,5 @@ export function treePostOrderBreadthFirstSearch<T>(
 	tree: Tree<T>,
 	parentRef: ChainedObject | undefined,
 ) {
-	return treePostOrderTraversal(tree, new Queue(), parentRef);
+	return treePostOrderTraversal(tree, new Queue(), parentRef, undefined);
 }

--- a/src/utils/graphs/tree-post-order-breadth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-breadth-first-search.ts
@@ -1,0 +1,16 @@
+import { ChainedObject, Tree } from 'src/types';
+import { Queue } from './queue';
+import { treePostOrderTraversal } from './tree-post-order-traversal';
+
+/**
+ * Implementation of pre order traversal, breadth first search algorithm for Trees
+ * @param tree The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export function treePostOrderBreadthFirstSearch<T>(
+	tree: Tree<T>,
+	parentRef: ChainedObject | undefined,
+) {
+	return treePostOrderTraversal(tree, new Queue(), parentRef);
+}

--- a/src/utils/graphs/tree-post-order-depth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-depth-first-search.ts
@@ -1,0 +1,15 @@
+import { ChainedObject, Tree } from 'src/types';
+import { treePostOrderTraversal } from './tree-post-order-traversal';
+
+/**
+ * Implementation of pre order traversal, depth first search algorithm for Trees
+ * @param tree The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export function treePostOrderDepthFirstSearch<T>(
+	tree: Tree<T>,
+	parentRef: ChainedObject | undefined,
+) {
+	return treePostOrderTraversal(tree, [], parentRef);
+}

--- a/src/utils/graphs/tree-post-order-depth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-depth-first-search.ts
@@ -11,5 +11,5 @@ export function treePostOrderDepthFirstSearch<T>(
 	tree: Tree<T>,
 	parentRef: ChainedObject | undefined,
 ) {
-	return treePostOrderTraversal(tree, [], parentRef);
+	return treePostOrderTraversal(tree, [], parentRef, undefined);
 }

--- a/src/utils/graphs/tree-post-order-traversal.ts
+++ b/src/utils/graphs/tree-post-order-traversal.ts
@@ -1,53 +1,41 @@
-import { ChainedObject, Tree, TreeKeys } from '../../types';
+import { ChainedObject, Tree, TreeKeys } from 'src/types';
 import { createTraversalItem } from './create-traversal-item';
 import { SimpleList, TraversalItem } from './graph-types';
 
 /**
  * Implementation of pre order traversal for Trees
- * @param root The tree to be traversed
+ * @param treeRef The tree to be traversed
  * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function* treePostOrderTraversal<T>(
-	root: Tree<T>,
-	list: SimpleList<
-		[Tree<T>, number, string | undefined, ChainedObject | undefined]
-	>,
-	startParentRef: ChainedObject | undefined,
+	treeRef: Tree<T>,
+	list: SimpleList<[Tree<T>, string | undefined, ChainedObject | undefined]>,
+	parentRef: ChainedObject | undefined,
+	key: string | undefined,
 ): Iterable<TraversalItem<T>> {
-	list.push([root, startParentRef?.level ?? 0, undefined, startParentRef]);
-	while (list.length > 0) {
-		const item = list.pop();
-		if (!item) {
-			throw new TypeError('Something went wrong processing list structure');
-		}
-		const [treeRef, level, key, parentRef] = item;
-		const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
-		let node: ChainedObject | TraversalItem<T> | undefined;
-		let traversalItem: TraversalItem<T> | undefined;
-		if (key === undefined) {
-			node = parentRef;
-		} else {
-			node = traversalItem = createTraversalItem(
-				key,
-				level,
-				parentRef,
-				treeRef,
-				value,
-			);
-		}
-		if (children) {
-			const nextLevel = level + 1;
-			// eslint-disable-next-line guard-for-in
-			for (const nextKey in children) {
-				const nextValue = children[nextKey];
-				if (nextValue) {
-					list.push([nextValue, nextLevel, nextKey, node]);
-				}
+	const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
+	const level = parentRef?.level ?? 0;
+	let node: TraversalItem<T> | undefined;
+	if (key !== undefined) {
+		node = createTraversalItem(key, level + 1, parentRef, treeRef, value);
+	}
+	if (children) {
+		// eslint-disable-next-line guard-for-in
+		for (const nextKey in children) {
+			const nextTree = children[nextKey];
+			if (nextTree) {
+				list.push([nextTree, nextKey, node]);
+				yield* treePostOrderTraversal<T>(
+					nextTree,
+					list,
+					node ?? parentRef,
+					nextKey,
+				);
 			}
 		}
-		if (traversalItem) {
-			yield traversalItem;
-		}
+	}
+	if (node) {
+		yield node;
 	}
 }

--- a/src/utils/graphs/tree-post-order-traversal.ts
+++ b/src/utils/graphs/tree-post-order-traversal.ts
@@ -1,0 +1,53 @@
+import { ChainedObject, Tree, TreeKeys } from '../../types';
+import { createTraversalItem } from './create-traversal-item';
+import { SimpleList, TraversalItem } from './graph-types';
+
+/**
+ * Implementation of pre order traversal for Trees
+ * @param root The tree to be traversed
+ * @param keyNames the name for each node level. The level will be assumed as the name if it is not provided
+ * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
+ */
+export function* treePostOrderTraversal<T>(
+	root: Tree<T>,
+	list: SimpleList<
+		[Tree<T>, number, string | undefined, ChainedObject | undefined]
+	>,
+	startParentRef: ChainedObject | undefined,
+): Iterable<TraversalItem<T>> {
+	list.push([root, startParentRef?.level ?? 0, undefined, startParentRef]);
+	while (list.length > 0) {
+		const item = list.pop();
+		if (!item) {
+			throw new TypeError('Something went wrong processing list structure');
+		}
+		const [treeRef, level, key, parentRef] = item;
+		const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
+		let node: ChainedObject | TraversalItem<T> | undefined;
+		let traversalItem: TraversalItem<T> | undefined;
+		if (key === undefined) {
+			node = parentRef;
+		} else {
+			node = traversalItem = createTraversalItem(
+				key,
+				level,
+				parentRef,
+				treeRef,
+				value,
+			);
+		}
+		if (children) {
+			const nextLevel = level + 1;
+			// eslint-disable-next-line guard-for-in
+			for (const nextKey in children) {
+				const nextValue = children[nextKey];
+				if (nextValue) {
+					list.push([nextValue, nextLevel, nextKey, node]);
+				}
+			}
+		}
+		if (traversalItem) {
+			yield traversalItem;
+		}
+	}
+}

--- a/test/unit/tree-key-cache.spec.ts
+++ b/test/unit/tree-key-cache.spec.ts
@@ -1470,6 +1470,47 @@ describe(TreeKeyCache.name, () => {
 				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
 			]);
 		});
+
+		it('should return every node that matches with the given tree level path', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+
+			const result = await toArray(
+				target.postOrderDepthFirstSearch(['a', 'b', 'c', 'd']),
+			);
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
+			]);
+		});
 	});
 
 	describe(proto.preOrderBreadthFirstSearch.name, () => {
@@ -1676,6 +1717,48 @@ describe(TreeKeyCache.name, () => {
 				{ key: 'c', level: 3, value: { value: 30 }, chainedKey: 'a:b:c' },
 				{ key: 'c2', level: 3, value: 'v2', chainedKey: 'a:b:c2' },
 				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
+			]);
+		});
+
+		it('should return every node of the storage when preOrderBreadthFirstSearch is called with a given tree level path', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+			map.set('a:b:c2', JSON.stringify('v2'));
+
+			const result = await toArray(
+				target.postOrderBreadthFirstSearch(['a', 'b', 'c', 'd']),
+			);
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
 			]);
 		});
 	});

--- a/test/unit/tree-key-cache.spec.ts
+++ b/test/unit/tree-key-cache.spec.ts
@@ -1370,6 +1370,108 @@ describe(TreeKeyCache.name, () => {
 		});
 	});
 
+	describe(proto.postOrderDepthFirstSearch.name, () => {
+		it('should throw an error when the method is called with a key level path but no getChildren is implemented on the storage', async () => {
+			let thrownError: any;
+
+			try {
+				await toArray(target.postOrderDepthFirstSearch());
+			} catch (err) {
+				thrownError = err;
+			}
+
+			expect(thrownError).toBeInstanceOf(Error);
+		});
+
+		it('should return every node of the storage when preOrderDepthFirstSearch is called with no parameters', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+
+			const result = await toArray(target.postOrderDepthFirstSearch());
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
+				{ key: 'c', level: 3, value: { value: 30 }, chainedKey: 'a:b:c' },
+				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
+				{ key: 'a', level: 1, value: { value: 10 }, chainedKey: 'a' },
+				{ key: 'c1', level: 3, value: 'b', chainedKey: 'a1:b1:c1' },
+				{ key: 'b1', level: 2, value: undefined, chainedKey: 'a1:b1' },
+				{ key: 'a1', level: 1, value: 'a', chainedKey: 'a1' },
+			]);
+		});
+
+		it('should return every node that matches with the given path', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+
+			const result = await toArray(
+				target.postOrderDepthFirstSearch(['a', 'b']),
+			);
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
+				{ key: 'c', level: 3, value: { value: 30 }, chainedKey: 'a:b:c' },
+				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
+			]);
+		});
+	});
+
 	describe(proto.preOrderBreadthFirstSearch.name, () => {
 		it('should throw an error when the method is called with a key level path but no getChildren is implemented on the storage', async () => {
 			let thrownError: any;
@@ -1470,6 +1572,110 @@ describe(TreeKeyCache.name, () => {
 				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
 				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
 				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+			]);
+		});
+	});
+
+	describe(proto.postOrderBreadthFirstSearch.name, () => {
+		it('should throw an error when the method is called with a key level path but no getChildren is implemented on the storage', async () => {
+			let thrownError: any;
+
+			try {
+				await toArray(target.postOrderBreadthFirstSearch());
+			} catch (err) {
+				thrownError = err;
+			}
+
+			expect(thrownError).toBeInstanceOf(Error);
+		});
+
+		it('should return every node of the storage when preOrderBreadthFirstSearch is called with no parameters', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+
+			const result = await toArray(target.postOrderBreadthFirstSearch());
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
+				{ key: 'c', level: 3, value: { value: 30 }, chainedKey: 'a:b:c' },
+				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
+				{ key: 'a', level: 1, value: { value: 10 }, chainedKey: 'a' },
+				{ key: 'c1', level: 3, value: 'b', chainedKey: 'a1:b1:c1' },
+				{ key: 'b1', level: 2, value: undefined, chainedKey: 'a1:b1' },
+				{ key: 'a1', level: 1, value: 'a', chainedKey: 'a1' },
+			]);
+		});
+
+		it('should return every node of the storage when preOrderBreadthFirstSearch is called with a given path', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+			map.set('a:b:c2', JSON.stringify('v2'));
+
+			const result = await toArray(
+				target.postOrderBreadthFirstSearch(['a', 'b']),
+			);
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
+				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
+				{ key: 'c', level: 3, value: { value: 30 }, chainedKey: 'a:b:c' },
+				{ key: 'c2', level: 3, value: 'v2', chainedKey: 'a:b:c2' },
+				{ key: 'b', level: 2, value: { value: 20 }, chainedKey: 'a:b' },
 			]);
 		});
 	});


### PR DESCRIPTION
For some next evolution we need this library to support post order tree traversing. To do so and to keep the code clean:
* We used @codibre/fluent-iterable to decrease async iteration chain performance impact;
* We refactored the pre order traversal methods so a unique logic can be used between them;
* We used the refactored methods to create the post order traversal methods