### PR TITLE
feat: implementing storage value versioning support

### DIFF
--- a/src/async-tree-ref.ts
+++ b/src/async-tree-ref.ts
@@ -69,7 +69,6 @@ export class AsyncTreeRef<R> implements AsyncTree<R> {
 						? this.options.treeSerializer.deserialize(value)
 						: new MultiTreeRef<R>(
 								traversalItem,
-								await getMultiValueFromAsyncIterable(value),
 								await getTreeListFromAsyncIterable(
 									this.options.treeSerializer,
 									value,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './types';
 export * from './tree-key-cache';
+export * from './types';
 export { buildKey } from './utils/graphs';
 export { deserializeWholeTree, EmptyTree, TreeError } from './utils';

--- a/src/multi-tree-ref.ts
+++ b/src/multi-tree-ref.ts
@@ -6,8 +6,6 @@ import {
 	MultiTreeValue,
 	Tree,
 	TreeKeys,
-	TreeValue,
-	multiTreeValue,
 } from './types';
 import { createTraversalItem } from './utils/graphs';
 import { getMultiValueFromTrees, isUndefined } from './utils';
@@ -17,16 +15,9 @@ export class MultiTreeRef<R> implements MultiTree<R> {
 	[TreeKeys.value]?: MultiTreeValue<R>;
 	constructor(
 		private nodeRef: ChainedObject | undefined,
-		value: TreeValue<R> | undefined,
 		private trees: Tree<R>[],
 	) {
-		this[TreeKeys.value] =
-			isUndefined(value) ||
-			(typeof value === 'object' && value && multiTreeValue in value)
-				? value
-				: {
-						[multiTreeValue]: [value],
-				  };
+		this[TreeKeys.value] = getMultiValueFromTrees(trees);
 	}
 
 	get [TreeKeys.children](): MultiTreeChildren<R> | undefined {
@@ -50,7 +41,6 @@ export class MultiTreeRef<R> implements MultiTree<R> {
 				({ key, trees }) =>
 					new MultiTreeRef<R>(
 						createTraversalItem<R>(key, 0, this.nodeRef, this),
-						getMultiValueFromTrees(trees),
 						trees,
 					),
 			);

--- a/src/multi-tree-ref.ts
+++ b/src/multi-tree-ref.ts
@@ -1,0 +1,65 @@
+import { fluent, fluentObject } from '@codibre/fluent-iterable';
+import {
+	ChainedObject,
+	MultiTree,
+	MultiTreeChildren,
+	MultiTreeValue,
+	Tree,
+	TreeKeys,
+	TreeValue,
+	multiTreeValue,
+} from './types';
+import { createTraversalItem } from './utils/graphs';
+import { getMultiValueFromTrees, isUndefined } from './utils';
+
+export class MultiTreeRef<R> implements MultiTree<R> {
+	#emptyChildren = false;
+	[TreeKeys.value]?: MultiTreeValue<R>;
+	constructor(
+		private nodeRef: ChainedObject | undefined,
+		value: TreeValue<R> | undefined,
+		private trees: Tree<R>[],
+	) {
+		this[TreeKeys.value] =
+			isUndefined(value) ||
+			(typeof value === 'object' && value && multiTreeValue in value)
+				? value
+				: {
+						[multiTreeValue]: [value],
+				  };
+	}
+
+	get [TreeKeys.children](): MultiTreeChildren<R> | undefined {
+		if (this.#emptyChildren) {
+			return undefined;
+		}
+		return fluent(this.trees)
+			.map((tree) => tree?.[TreeKeys.children])
+			.filter()
+			.flatMap((x) =>
+				fluentObject(x)
+					.filter(1)
+					.map(([key, tree]) => ({ key, trees: [tree] })),
+			)
+			.distinct('key', (a, b) => {
+				a.trees.push(...b.trees);
+				return a;
+			})
+			.toObject(
+				'key',
+				({ key, trees }) =>
+					new MultiTreeRef<R>(
+						createTraversalItem<R>(key, 0, this.nodeRef, this),
+						getMultiValueFromTrees(trees),
+						trees,
+					),
+			);
+	}
+
+	set [TreeKeys.children](tree: MultiTreeChildren<R> | undefined) {
+		if (!isUndefined(tree)) {
+			throw new Error('MultiTreeRef only allow setting children to undefined');
+		}
+		this.#emptyChildren = true;
+	}
+}

--- a/src/tree-key-cache.ts
+++ b/src/tree-key-cache.ts
@@ -907,6 +907,12 @@ export class TreeKeyCache<
 			});
 	}
 
+	/**
+	 * Returns an async iterable that traverses the tree on a pre order, breadth first search fashion.
+	 * To perform traversals on key level nodes, you need to have implemented the getChildren method
+	 * on the storage. Traversals on tree level nodes are always supported
+	 * @param basePath The base path to be traversed
+	 */
 	preOrderBreadthFirstSearch(basePath?: string[]) {
 		return this.getTraversalStepsIterable(
 			asyncTreePreOrderBreadthFirstSearch,
@@ -916,6 +922,12 @@ export class TreeKeyCache<
 		);
 	}
 
+	/**
+	 * Returns an async iterable that traverses the tree on a pre order, depth first search fashion.
+	 * To perform traversals on key level nodes, you need to have implemented the getChildren method
+	 * on the storage. Traversals on tree level nodes are always supported
+	 * @param basePath The base path to be traversed
+	 */
 	preOrderDepthFirstSearch(basePath?: string[]): AsyncIterable<Step<T>> {
 		return this.getTraversalStepsIterable(
 			asyncTreePreOrderDepthFirstSearch,
@@ -925,15 +937,12 @@ export class TreeKeyCache<
 		);
 	}
 
-	postOrderDepthFirstSearch(basePath?: string[]): AsyncIterable<Step<T>> {
-		return this.getTraversalStepsIterable(
-			asyncTreePostOrderDepthFirstSearch,
-			treePostOrderDepthFirstSearch,
-			'append',
-			basePath,
-		);
-	}
-
+	/**
+	 * Returns an async iterable that traverses the tree on a post order, breadth first search fashion.
+	 * To perform traversals on key level nodes, you need to have implemented the getChildren method
+	 * on the storage. Traversals on tree level nodes are always supported
+	 * @param basePath The base path to be traversed
+	 */
 	postOrderBreadthFirstSearch(basePath?: string[]): AsyncIterable<Step<T>> {
 		return this.getTraversalStepsIterable(
 			asyncTreePostOrderBreadthFirstSearch,
@@ -943,6 +952,28 @@ export class TreeKeyCache<
 		);
 	}
 
+	/**
+	 * Returns an async iterable that traverses the tree on a post order, depth first search fashion.
+	 * To perform traversals on key level nodes, you need to have implemented the getChildren method
+	 * on the storage. Traversals on tree level nodes are always supported
+	 * @param basePath The base path to be traversed
+	 */
+	postOrderDepthFirstSearch(basePath?: string[]): AsyncIterable<Step<T>> {
+		return this.getTraversalStepsIterable(
+			asyncTreePostOrderDepthFirstSearch,
+			treePostOrderDepthFirstSearch,
+			'append',
+			basePath,
+		);
+	}
+
+	/**
+	 * Reprocess all the key level nodes, registering every key children of them.
+	 * To use this method, randomIterate and registerChild must be implemented on the storage.
+	 * Optionally, clearAllChildrenRegistry can also be implemented, which will make
+	 * all the previously registered children be excluded before performing the operation
+	 * @param partition how many children will be registered per time
+	 */
 	async *reprocessAllKeyLevelChildren(partition = 1) {
 		if (!this.storage.randomIterate || !this.storage.registerChild) {
 			throw new TypeError(
@@ -1096,6 +1127,10 @@ export class TreeKeyCache<
 		return changed;
 	}
 
+	/**
+	 * Performs a prune, removing all empty or expired nodes from tree level nodes.
+	 * @param pattern The pattern of storage keys to be pruned. If not informed, all tree level keys will be pruned.
+	 */
 	async prune(pattern?: string) {
 		await fluentAsync(this.internalRandomIterate(pattern, false, true))
 			.filter()

--- a/src/tree-key-cache.ts
+++ b/src/tree-key-cache.ts
@@ -195,15 +195,7 @@ export class TreeKeyCache<
 				.filter()
 				.map((buffer) => this.options.treeSerializer.deserialize(buffer))
 				.toArray();
-			const value = nodeRef
-				? {
-						[multiTreeValue]: fluent(trees)
-							.map(TreeKeys.value)
-							.filter()
-							.toArray(),
-				  }
-				: undefined;
-			return new MultiTreeRef<R>(nodeRef, value, trees);
+			return new MultiTreeRef<R>(nodeRef, trees);
 		} catch (error) {
 			this.emit('deserializeError', error, 'tree');
 		}
@@ -390,7 +382,6 @@ export class TreeKeyCache<
 				if (isAsyncIterable(buffer)) {
 					tree = new MultiTreeRef(
 						nodeRef,
-						nodeRef[valueSymbol],
 						await fluentAsync(buffer)
 							.filter()
 							.map((buff) => this.options.treeSerializer.deserialize(buff))

--- a/src/types/key-tree-cache-options.ts
+++ b/src/types/key-tree-cache-options.ts
@@ -9,6 +9,13 @@ export interface Serializer<A, B> {
 	deserialize(b: B): A;
 }
 
+export interface ValueSerializer<A, B> extends Serializer<A, B> {
+	deserializeList?(b: Iterable<B | undefined>): A | undefined;
+	deserializeAsyncList?(
+		b: AsyncIterable<B | undefined>,
+	): Promise<A | undefined>;
+}
+
 export interface Memoizer {
 	get<B>(key: string): B | undefined;
 	set<B>(key: string, value: B): unknown;
@@ -16,7 +23,7 @@ export interface Memoizer {
 
 export interface KeyTreeCacheOptions<T, R = string> {
 	keyLevelNodes: number;
-	valueSerializer?: Serializer<T, R>;
+	valueSerializer?: ValueSerializer<T, R>;
 	treeSerializer?: Serializer<Tree<R>, R>;
 	semaphore?: Semaphore;
 	memoizer?: Memoizer;

--- a/src/types/key-tree-cache-storage.ts
+++ b/src/types/key-tree-cache-storage.ts
@@ -1,11 +1,48 @@
 export interface KeyTreeCacheStorage<R = string> {
+	/**
+	 * Clear all the current key children registered
+	 */
 	clearAllChildrenRegistry?(): Promise<void>;
+	/**
+	 * Returns the value for the given key
+	 * @param key The key to be looked up for
+	 */
 	get(key: string): Promise<R | undefined> | R | undefined;
+	/**
+	 * Returns all the non expired values registered for the given key.
+	 * This is useful if you want to have a processed value based on
+	 * the latest history items. In that case, the saving fashion
+	 * must be controlled by the set method implementation
+	 * @param key Re
+	 */
 	getHistory?(key: string): AsyncIterable<R | undefined>;
+	/**
+	 * Saves the given value into the given key, with the given ttl, if informed
+	 * @param key The key where the value will be persisted
+	 * @param value The value to be saved
+	 * @param ttl Optional. The ttl os the value, in seconds
+	 */
 	set(key: string, value: R, ttl?: number): Promise<unknown> | unknown;
+	/**
+	 * Returns all the children of a given key. To be used with key level keys
+	 * @param key The parent key
+	 */
 	getChildren?(key?: string): AsyncIterable<string>;
+	/**
+	 * Returns the current ttl of the given key
+	 * @param key The key
+	 */
 	getCurrentTtl(key: string): Promise<number | undefined> | number | undefined;
+	/**
+	 * Returns an async iterable that yields all the keys that matches the given pattern
+	 * @param pattern The pattern to match the keys. If not informed, all keys are returned
+	 */
 	randomIterate?(pattern?: string): AsyncIterable<string>;
+	/**
+	 * Register a child for a given key
+	 * @param parentKey the parent chained key (in the buildKey return format)
+	 * @param partialKey The child key (not chained)
+	 */
 	registerChild?(
 		parentKey: string | undefined,
 		partialKey: string,

--- a/src/types/key-tree-cache-storage.ts
+++ b/src/types/key-tree-cache-storage.ts
@@ -1,7 +1,7 @@
 export interface KeyTreeCacheStorage<R = string> {
 	clearAllChildrenRegistry?(): Promise<void>;
 	get(key: string): Promise<R | undefined> | R | undefined;
-	getVersions?(key: string): AsyncIterable<R | undefined>;
+	getHistory?(key: string): AsyncIterable<R | undefined>;
 	set(key: string, value: R, ttl?: number): Promise<unknown> | unknown;
 	getChildren?(key?: string): AsyncIterable<string>;
 	getCurrentTtl(key: string): Promise<number | undefined> | number | undefined;

--- a/src/types/key-tree-cache-storage.ts
+++ b/src/types/key-tree-cache-storage.ts
@@ -1,6 +1,7 @@
 export interface KeyTreeCacheStorage<R = string> {
 	clearAllChildrenRegistry?(): Promise<void>;
 	get(key: string): Promise<R | undefined> | R | undefined;
+	getVersions?(key: string): AsyncIterable<R | undefined>;
 	set(key: string, value: R, ttl?: number): Promise<unknown> | unknown;
 	getChildren?(key?: string): AsyncIterable<string>;
 	getCurrentTtl(key: string): Promise<number | undefined> | number | undefined;

--- a/src/types/tree-type.ts
+++ b/src/types/tree-type.ts
@@ -2,9 +2,10 @@ export type KeyType = string;
 export type TreeChildren<T> = {
 	[t in KeyType]: Tree<T> | undefined;
 };
-export type AsyncTreeChildren<T> = AsyncIterable<
-	[KeyType, AsyncTree<T> | Tree<T>]
->;
+export type AsyncTreeChildren<T> = AsyncIterable<[KeyType, AnyTree<T>]>;
+export type MultiTreeChildren<T> = {
+	[t in KeyType]: MultiTree<T> | undefined;
+};
 
 export enum TreeKeys {
 	children = 'c',
@@ -17,8 +18,21 @@ export interface BaseTree<T> {
 	[TreeKeys.children]?: object;
 }
 
-export interface AsyncTree<T> extends BaseTree<T> {
+export type TreeValue<T> = T | MultiTreeValue<T>;
+
+export interface AsyncTree<T> extends BaseTree<TreeValue<T>> {
 	[TreeKeys.children]?: () => AsyncTreeChildren<T>;
+}
+
+export const multiTreeValue = Symbol('multiTreeValue');
+
+export interface MultiTreeValue<T> {
+	[multiTreeValue]: T[];
+}
+
+export interface MultiTree<T> extends BaseTree<MultiTreeValue<T>> {
+	[TreeKeys.children]?: MultiTreeChildren<T>;
+	[TreeKeys.deadline]?: number;
 }
 
 export interface Tree<T> extends BaseTree<T> {
@@ -26,7 +40,8 @@ export interface Tree<T> extends BaseTree<T> {
 	[TreeKeys.deadline]?: number;
 }
 
-export type StorageTree<T> = Tree<T> | AsyncTree<T>;
+export type SyncTree<T> = Tree<T> | MultiTree<T>;
+export type AnyTree<T> = SyncTree<T> | AsyncTree<T>;
 
 export interface Step<T> {
 	value: T | undefined;

--- a/src/utils/get-multi-value-from-async-iterable.ts
+++ b/src/utils/get-multi-value-from-async-iterable.ts
@@ -1,0 +1,10 @@
+import { fluentAsync } from '@codibre/fluent-iterable';
+import { multiTreeValue } from '../types';
+
+export async function getMultiValueFromAsyncIterable<R>(
+	value: AsyncIterable<R | undefined>,
+) {
+	return {
+		[multiTreeValue]: await fluentAsync(value).filter().toArray(),
+	};
+}

--- a/src/utils/get-multi-value-from-trees.ts
+++ b/src/utils/get-multi-value-from-trees.ts
@@ -1,0 +1,8 @@
+import { Tree, TreeKeys, multiTreeValue } from '../types';
+import { fluent } from '@codibre/fluent-iterable';
+
+export function getMultiValueFromTrees<R>(trees: Tree<R>[]) {
+	return {
+		[multiTreeValue]: fluent(trees).map(TreeKeys.value).filter().toArray(),
+	};
+}

--- a/src/utils/get-read-storage-function.ts
+++ b/src/utils/get-read-storage-function.ts
@@ -1,0 +1,5 @@
+import { KeyTreeCacheStorage } from 'src/types';
+
+export function getReadStorageFunction<R>(storage: KeyTreeCacheStorage<R>) {
+	return storage.getVersions?.bind(storage) ?? storage.get.bind(storage);
+}

--- a/src/utils/get-read-storage-function.ts
+++ b/src/utils/get-read-storage-function.ts
@@ -1,5 +1,5 @@
 import { KeyTreeCacheStorage } from 'src/types';
 
 export function getReadStorageFunction<R>(storage: KeyTreeCacheStorage<R>) {
-	return storage.getVersions?.bind(storage) ?? storage.get.bind(storage);
+	return storage.getHistory?.bind(storage) ?? storage.get.bind(storage);
 }

--- a/src/utils/get-tree-list-from-async-iterable.ts
+++ b/src/utils/get-tree-list-from-async-iterable.ts
@@ -1,0 +1,12 @@
+import { Serializer, Tree } from 'src/types';
+import { fluentAsync } from '@codibre/fluent-iterable';
+
+export function getTreeListFromAsyncIterable<R>(
+	treeSerializer: Serializer<Tree<R>, R>,
+	value: AsyncIterable<R | undefined>,
+) {
+	return fluentAsync(value)
+		.filter()
+		.map((buffer) => treeSerializer.deserialize(buffer))
+		.toArray();
+}

--- a/src/utils/graphs/async/async-struct-helper.ts
+++ b/src/utils/graphs/async/async-struct-helper.ts
@@ -14,10 +14,3 @@ export function isAsyncIterator<T>(
 ): value is AsyncIterator<T> {
 	return value !== null && typeof value === 'object' && 'next' in value;
 }
-export function isAsyncIterable<T>(
-	value: AsyncIterable<T> | T | undefined,
-): value is AsyncIterable<T> {
-	return (
-		value !== null && typeof value === 'object' && Symbol.asyncIterator in value
-	);
-}

--- a/src/utils/graphs/async/aync-queue.ts
+++ b/src/utils/graphs/async/aync-queue.ts
@@ -1,9 +1,5 @@
-import {
-	AsyncSimpleList,
-	Node,
-	isAsyncIterable,
-	isAsyncIterator,
-} from './async-struct-helper';
+import { isAsyncIterable } from '@codibre/fluent-iterable';
+import { AsyncSimpleList, Node, isAsyncIterator } from './async-struct-helper';
 
 export class AsyncQueue<T> implements AsyncSimpleList<T> {
 	private next: Node<T | AsyncIterator<T>> | undefined;

--- a/src/utils/graphs/async/aync-stack.ts
+++ b/src/utils/graphs/async/aync-stack.ts
@@ -1,4 +1,5 @@
-import { AsyncSimpleList, isAsyncIterable } from './async-struct-helper';
+import { isAsyncIterable } from '@codibre/fluent-iterable';
+import { AsyncSimpleList } from './async-struct-helper';
 
 export class AsyncStack<T> implements AsyncSimpleList<T> {
 	private stack: Array<T> = [];

--- a/src/utils/graphs/create-traversal-item.ts
+++ b/src/utils/graphs/create-traversal-item.ts
@@ -1,7 +1,18 @@
-import { AsyncTree, ChainedObject, StorageTree, Tree } from '../../types';
+import {
+	AsyncTree,
+	ChainedObject,
+	MultiTree,
+	MultiTreeValue,
+	AnyTree,
+	SyncTree,
+	TreeValue,
+	Tree,
+} from '../../types';
 import {
 	AsyncTraversalItem,
-	StorageTraversalItem,
+	MultiTraversalItem,
+	AnyTraversalItem,
+	SyncTraversalItem,
 	TraversalItem,
 	treeRefSymbol,
 	valueSymbol,
@@ -25,16 +36,30 @@ export function createTraversalItem<T>(
 	key: string,
 	level: number,
 	parentRef: ChainedObject | undefined,
-	treeRef: StorageTree<T>,
-	value?: T,
-): StorageTraversalItem<T>;
+	treeRef: MultiTree<T>,
+	value?: MultiTreeValue<T>,
+): MultiTraversalItem<T>;
 export function createTraversalItem<T>(
 	key: string,
 	level: number,
 	parentRef: ChainedObject | undefined,
-	treeRef: StorageTree<T>,
+	treeRef: SyncTree<T>,
+	value?: TreeValue<T>,
+): SyncTraversalItem<T>;
+export function createTraversalItem<T>(
+	key: string,
+	level: number,
+	parentRef: ChainedObject | undefined,
+	treeRef: AnyTree<T>,
+	value?: TreeValue<T>,
+): AnyTraversalItem<T>;
+export function createTraversalItem<T>(
+	key: string,
+	level: number,
+	parentRef: ChainedObject | undefined,
+	treeRef: AnyTree<T>,
 	value?: T,
-): StorageTraversalItem<T> {
+): AnyTraversalItem<T> {
 	return {
 		key,
 		parentRef,

--- a/src/utils/graphs/graph-types.ts
+++ b/src/utils/graphs/graph-types.ts
@@ -1,4 +1,11 @@
-import { ChainedObject, StorageTree, Tree } from 'src/types';
+import {
+	ChainedObject,
+	MultiTree,
+	MultiTreeValue,
+	AnyTree,
+	TreeValue,
+	Tree,
+} from 'src/types';
 
 export interface SimpleList<T> {
 	push(item: T): unknown;
@@ -14,15 +21,18 @@ export interface BaseTraversalItem<T> extends ChainedObject {
 	[treeRefSymbol]: object;
 }
 
-export interface AsyncTraversalItem<T> extends BaseTraversalItem<T> {
-	[valueSymbol]: T | undefined;
-	[treeRefSymbol]: StorageTree<T>;
+export interface AsyncTraversalItem<T> extends BaseTraversalItem<TreeValue<T>> {
+	[treeRefSymbol]: AnyTree<T>;
 }
 
 export interface TraversalItem<T> extends BaseTraversalItem<T> {
 	[treeRefSymbol]: Tree<T>;
 }
 
-export interface StorageTraversalItem<T> extends BaseTraversalItem<T> {
-	[treeRefSymbol]: StorageTree<T>;
+export interface MultiTraversalItem<T>
+	extends BaseTraversalItem<MultiTreeValue<T>> {
+	[treeRefSymbol]: MultiTree<T>;
 }
+
+export type SyncTraversalItem<T> = TraversalItem<T> | MultiTraversalItem<T>;
+export type AnyTraversalItem<T> = SyncTraversalItem<T> | AsyncTraversalItem<T>;

--- a/src/utils/graphs/tree-post-order-breadth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-breadth-first-search.ts
@@ -1,4 +1,4 @@
-import { ChainedObject, Tree } from 'src/types';
+import { ChainedObject, SyncTree } from 'src/types';
 import { Queue } from './queue';
 import { treePostOrderTraversal } from './tree-post-order-traversal';
 
@@ -9,7 +9,7 @@ import { treePostOrderTraversal } from './tree-post-order-traversal';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function treePostOrderBreadthFirstSearch<T>(
-	tree: Tree<T>,
+	tree: SyncTree<T>,
 	parentRef: ChainedObject | undefined,
 ) {
 	return treePostOrderTraversal(tree, new Queue(), parentRef, undefined);

--- a/src/utils/graphs/tree-post-order-depth-first-search.ts
+++ b/src/utils/graphs/tree-post-order-depth-first-search.ts
@@ -1,4 +1,4 @@
-import { ChainedObject, Tree } from 'src/types';
+import { ChainedObject, SyncTree } from 'src/types';
 import { treePostOrderTraversal } from './tree-post-order-traversal';
 
 /**
@@ -8,7 +8,7 @@ import { treePostOrderTraversal } from './tree-post-order-traversal';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function treePostOrderDepthFirstSearch<T>(
-	tree: Tree<T>,
+	tree: SyncTree<T>,
 	parentRef: ChainedObject | undefined,
 ) {
 	return treePostOrderTraversal(tree, [], parentRef, undefined);

--- a/src/utils/graphs/tree-post-order-traversal.ts
+++ b/src/utils/graphs/tree-post-order-traversal.ts
@@ -1,6 +1,6 @@
-import { ChainedObject, Tree, TreeKeys } from 'src/types';
+import { ChainedObject, SyncTree, TreeKeys } from 'src/types';
 import { createTraversalItem } from './create-traversal-item';
-import { SimpleList, TraversalItem } from './graph-types';
+import { SimpleList, SyncTraversalItem } from './graph-types';
 
 /**
  * Implementation of pre order traversal for Trees
@@ -9,16 +9,18 @@ import { SimpleList, TraversalItem } from './graph-types';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function* treePostOrderTraversal<T>(
-	treeRef: Tree<T>,
-	list: SimpleList<[Tree<T>, string | undefined, ChainedObject | undefined]>,
+	treeRef: SyncTree<T>,
+	list: SimpleList<
+		[SyncTree<T>, string | undefined, ChainedObject | undefined]
+	>,
 	parentRef: ChainedObject | undefined,
 	key: string | undefined,
-): Iterable<TraversalItem<T>> {
+): Iterable<SyncTraversalItem<T>> {
 	const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
 	const level = parentRef?.level ?? 0;
-	let node: TraversalItem<T> | undefined;
+	let node: SyncTraversalItem<T> | undefined;
 	if (key !== undefined) {
-		node = createTraversalItem(key, level + 1, parentRef, treeRef, value);
+		node = createTraversalItem<T>(key, level + 1, parentRef, treeRef, value);
 	}
 	if (children) {
 		// eslint-disable-next-line guard-for-in

--- a/src/utils/graphs/tree-pre-order-breadth-first-search.ts
+++ b/src/utils/graphs/tree-pre-order-breadth-first-search.ts
@@ -1,6 +1,11 @@
-import { ChainedObject, Tree } from 'src/types';
+import { ChainedObject, MultiTree, SyncTree, Tree } from 'src/types';
 import { Queue } from './queue';
 import { treePreOrderTraversal } from './tree-pre-order-traversal';
+import {
+	TraversalItem,
+	MultiTraversalItem,
+	SyncTraversalItem,
+} from './graph-types';
 
 /**
  * Implementation of pre order traversal, breadth first search algorithm for Trees
@@ -9,8 +14,20 @@ import { treePreOrderTraversal } from './tree-pre-order-traversal';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function treePreOrderBreadthFirstSearch<T>(
+	tree: MultiTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<MultiTraversalItem<T>>;
+export function treePreOrderBreadthFirstSearch<T>(
 	tree: Tree<T>,
 	parentRef: ChainedObject | undefined,
-) {
+): Iterable<TraversalItem<T>>;
+export function treePreOrderBreadthFirstSearch<T>(
+	tree: SyncTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<SyncTraversalItem<T>>;
+export function treePreOrderBreadthFirstSearch<T>(
+	tree: SyncTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<SyncTraversalItem<T>> {
 	return treePreOrderTraversal(tree, new Queue(), parentRef);
 }

--- a/src/utils/graphs/tree-pre-order-depth-first-search.ts
+++ b/src/utils/graphs/tree-pre-order-depth-first-search.ts
@@ -1,5 +1,10 @@
-import { ChainedObject, Tree } from 'src/types';
+import { ChainedObject, MultiTree, SyncTree, Tree } from 'src/types';
 import { treePreOrderTraversal } from './tree-pre-order-traversal';
+import {
+	TraversalItem,
+	MultiTraversalItem,
+	SyncTraversalItem,
+} from './graph-types';
 
 /**
  * Implementation of pre order traversal, depth first search algorithm for Trees
@@ -8,8 +13,20 @@ import { treePreOrderTraversal } from './tree-pre-order-traversal';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function treePreOrderDepthFirstSearch<T>(
+	tree: MultiTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<MultiTraversalItem<T>>;
+export function treePreOrderDepthFirstSearch<T>(
 	tree: Tree<T>,
 	parentRef: ChainedObject | undefined,
-) {
+): Iterable<TraversalItem<T>>;
+export function treePreOrderDepthFirstSearch<T>(
+	tree: SyncTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<SyncTraversalItem<T>>;
+export function treePreOrderDepthFirstSearch<T>(
+	tree: SyncTree<T>,
+	parentRef: ChainedObject | undefined,
+): Iterable<SyncTraversalItem<T>> {
 	return treePreOrderTraversal(tree, [], parentRef);
 }

--- a/src/utils/graphs/tree-pre-order-traversal.ts
+++ b/src/utils/graphs/tree-pre-order-traversal.ts
@@ -1,11 +1,6 @@
 import { ChainedObject, SyncTree, TreeKeys } from '../../types';
 import { createTraversalItem } from './create-traversal-item';
-import {
-	MultiTraversalItem,
-	SimpleList,
-	SyncTraversalItem,
-	TraversalItem,
-} from './graph-types';
+import { SimpleList, SyncTraversalItem } from './graph-types';
 
 /**
  * Implementation of pre order traversal for Trees
@@ -28,11 +23,7 @@ export function* treePreOrderTraversal<T>(
 		}
 		const [treeRef, level, key, parentRef] = item;
 		const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
-		let node:
-			| ChainedObject
-			| MultiTraversalItem<T>
-			| TraversalItem<T>
-			| undefined;
+		let node: ChainedObject | undefined;
 		if (key === undefined) {
 			node = parentRef;
 		} else {

--- a/src/utils/graphs/tree-pre-order-traversal.ts
+++ b/src/utils/graphs/tree-pre-order-traversal.ts
@@ -1,6 +1,11 @@
-import { ChainedObject, Tree, TreeKeys } from '../../types';
+import { ChainedObject, SyncTree, TreeKeys } from '../../types';
 import { createTraversalItem } from './create-traversal-item';
-import { SimpleList, TraversalItem } from './graph-types';
+import {
+	MultiTraversalItem,
+	SimpleList,
+	SyncTraversalItem,
+	TraversalItem,
+} from './graph-types';
 
 /**
  * Implementation of pre order traversal for Trees
@@ -9,12 +14,12 @@ import { SimpleList, TraversalItem } from './graph-types';
  * @returns An iterables of { keys, value } objects, where keys contains the id for each node on the path
  */
 export function* treePreOrderTraversal<T>(
-	root: Tree<T>,
+	root: SyncTree<T>,
 	list: SimpleList<
-		[Tree<T>, number, string | undefined, ChainedObject | undefined]
+		[SyncTree<T>, number, string | undefined, ChainedObject | undefined]
 	>,
 	startParentRef: ChainedObject | undefined,
-): Iterable<TraversalItem<T>> {
+): Iterable<SyncTraversalItem<T>> {
 	list.push([root, startParentRef?.level ?? 0, undefined, startParentRef]);
 	while (list.length > 0) {
 		const item = list.pop();
@@ -23,11 +28,21 @@ export function* treePreOrderTraversal<T>(
 		}
 		const [treeRef, level, key, parentRef] = item;
 		const { [TreeKeys.children]: children, [TreeKeys.value]: value } = treeRef;
-		let node: ChainedObject | TraversalItem<T> | undefined;
+		let node:
+			| ChainedObject
+			| MultiTraversalItem<T>
+			| TraversalItem<T>
+			| undefined;
 		if (key === undefined) {
 			node = parentRef;
 		} else {
-			yield (node = createTraversalItem(key, level, parentRef, treeRef, value));
+			yield (node = createTraversalItem<T>(
+				key,
+				level,
+				parentRef,
+				treeRef,
+				value,
+			));
 		}
 		if (children) {
 			const nextLevel = level + 1;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,4 +3,8 @@ export * from './deserialize-whole-tree';
 export * from './dont-wait';
 export * from './get-chained-key';
 export * from './get-key';
+export * from './get-multi-value-from-async-iterable';
+export * from './get-multi-value-from-trees';
+export * from './get-read-storage-function';
+export * from './get-tree-list-from-async-iterable';
 export * from './is-undefined';

--- a/test/unit/tree-key-cache.spec.ts
+++ b/test/unit/tree-key-cache.spec.ts
@@ -377,7 +377,7 @@ describe(TreeKeyCache.name, () => {
 		});
 
 		it('should throw an error during iteration when an async iterable is returned from storage.get but no deserializeAsyncList is implemented on Serializer', async () => {
-			target['storage'].getVersions = jest
+			target['storage'].getHistory = jest
 				.fn()
 				.mockReturnValue(fluentAsync([]) as any);
 			const { valueSerializer } = target['options'];
@@ -404,7 +404,7 @@ describe(TreeKeyCache.name, () => {
 
 		it('should return an iterable for the values stored in partial keys and in the tree-value deserialized with deserializeList, when asyncIterables are returned by stored.get', async () => {
 			const get = map.get.bind(map);
-			target['storage'].getVersions = jest.fn().mockImplementation((k): any => {
+			target['storage'].getHistory = jest.fn().mockImplementation((k): any => {
 				return fluentAsync([get(k)]);
 			});
 			const { valueSerializer } = target['options'];
@@ -1460,6 +1460,145 @@ describe(TreeKeyCache.name, () => {
 				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
 			]);
 		});
+
+		it('should return every node of the storage when getVersions is implemented', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			target['storage'].getHistory = function (key: string) {
+				const value = map.get(key);
+				return fluentAsync([
+					value,
+					key === 'a:b:c:d'
+						? JSON.stringify({
+								[TreeKeys.value]: 99,
+								[TreeKeys.children]: {
+									1: {
+										[TreeKeys.value]: 11,
+									},
+									2: {
+										[TreeKeys.value]: 22,
+									},
+									3: {
+										[TreeKeys.value]: 33,
+										[TreeKeys.children]: {
+											f: { v: 44 },
+										},
+									},
+									e: {
+										[TreeKeys.value]: 99,
+										[TreeKeys.children]: {
+											f: {
+												[TreeKeys.value]: 11,
+											},
+										},
+									},
+								},
+						  })
+						: value,
+				]);
+			};
+			const { valueSerializer } = target['options'];
+			valueSerializer.deserializeList = (b) => {
+				return {
+					value: fluent(b)
+						.filter()
+						.map((item) => valueSerializer.deserialize(item))
+						.map((x) => x.value ?? x)
+						.join(',', (x) => x.toString()) as any,
+				};
+			};
+			valueSerializer.deserializeAsyncList = async (b) => {
+				return {
+					value: (await fluentAsync(b)
+						.filter()
+						.map((item) => valueSerializer.deserialize(item))
+						.map((x) => x.value ?? x)
+						.join(',', (x) => x.toString())) as any,
+				};
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+			map.set('a:b:c2', JSON.stringify('v2'));
+
+			const result = await toArray(target.preOrderDepthFirstSearch(['a', 'b']));
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'b', level: 2, value: { value: '20,20' }, chainedKey: 'a:b' },
+				{
+					key: 'c2',
+					level: 3,
+					value: { value: 'v2,v2' },
+					chainedKey: 'a:b:c2',
+				},
+				{ key: 'c', level: 3, value: { value: '30,30' }, chainedKey: 'a:b:c' },
+				{
+					key: 'd',
+					level: 4,
+					value: { value: '40,99' },
+					chainedKey: 'a:b:c:d',
+				},
+				{
+					key: 'e',
+					level: 5,
+					value: { value: '50,99' },
+					chainedKey: 'a:b:c:d:e',
+				},
+				{
+					key: 'f',
+					level: 6,
+					value: { value: '60,11' },
+					chainedKey: 'a:b:c:d:e:f',
+				},
+				{
+					key: '3',
+					level: 5,
+					value: { value: '33' },
+					chainedKey: 'a:b:c:d:3',
+				},
+				{
+					key: 'f',
+					level: 6,
+					value: { value: '44' },
+					chainedKey: 'a:b:c:d:3:f',
+				},
+				{
+					key: '2',
+					level: 5,
+					value: { value: '22' },
+					chainedKey: 'a:b:c:d:2',
+				},
+				{
+					key: '1',
+					level: 5,
+					value: { value: '11' },
+					chainedKey: 'a:b:c:d:1',
+				},
+			]);
+		});
 	});
 
 	describe(proto.postOrderDepthFirstSearch.name, () => {
@@ -1705,6 +1844,139 @@ describe(TreeKeyCache.name, () => {
 				{ key: 'd', level: 4, value: { value: 40 }, chainedKey: 'a:b:c:d' },
 				{ key: 'e', level: 5, value: { value: 50 }, chainedKey: 'a:b:c:d:e' },
 				{ key: 'f', level: 6, value: { value: 60 }, chainedKey: 'a:b:c:d:e:f' },
+			]);
+		});
+
+		it('should return every node of the storage when getVersions is implemented', async () => {
+			target['storage'].getChildren = async function* (
+				start: string | undefined,
+			) {
+				const keys = map.keys();
+				const childSize = !start ? 1 : start.split(':').length + 1;
+				const set = new Set();
+				if (start) {
+					start = `${start}:`;
+				}
+
+				for (const key of keys) {
+					if (!start || (key !== start && key.startsWith(start))) {
+						const path = key.split(':').slice(0, childSize);
+						const childKey = buildKey(path);
+						if (!set.has(childKey)) {
+							set.add(childKey);
+							yield path[path.length - 1] as string;
+						}
+					}
+				}
+			};
+			target['storage'].getHistory = function (key: string) {
+				const value = map.get(key);
+				return fluentAsync([
+					value,
+					key === 'a:b:c:d'
+						? JSON.stringify({
+								[TreeKeys.value]: 99,
+								[TreeKeys.children]: {
+									1: {
+										[TreeKeys.value]: 11,
+									},
+									2: {
+										[TreeKeys.value]: 22,
+									},
+									3: {
+										[TreeKeys.value]: 33,
+										[TreeKeys.children]: {
+											4: { v: 44 },
+										},
+									},
+								},
+						  })
+						: value,
+				]);
+			};
+			const { valueSerializer } = target['options'];
+			valueSerializer.deserializeList = (b) => {
+				return {
+					value: fluent(b)
+						.filter()
+						.map((item) => valueSerializer.deserialize(item))
+						.map((x) => x.value ?? x)
+						.join(',', (x) => x.toString()) as any,
+				};
+			};
+			valueSerializer.deserializeAsyncList = async (b) => {
+				return {
+					value: (await fluentAsync(b)
+						.filter()
+						.map((item) => valueSerializer.deserialize(item))
+						.map((x) => x.value ?? x)
+						.join(',', (x) => x.toString())) as any,
+				};
+			};
+			map.set('a1', JSON.stringify('a'));
+			map.set('a1:b1:c1', JSON.stringify('b'));
+			map.set('a:b:c2', JSON.stringify('v2'));
+
+			const result = await toArray(
+				target.preOrderBreadthFirstSearch(['a', 'b']),
+			);
+
+			expect(
+				result.map(({ nodeRef, ...x }) => ({
+					...x,
+					chainedKey: buildKey(nodeRef),
+				})),
+			).toEqual([
+				{ key: 'b', level: 2, value: { value: '20,20' }, chainedKey: 'a:b' },
+				{ key: 'c', level: 3, value: { value: '30,30' }, chainedKey: 'a:b:c' },
+				{
+					key: 'c2',
+					level: 3,
+					value: { value: 'v2,v2' },
+					chainedKey: 'a:b:c2',
+				},
+				{
+					key: 'd',
+					level: 4,
+					value: { value: '40,99' },
+					chainedKey: 'a:b:c:d',
+				},
+				{
+					key: '1',
+					level: 5,
+					value: { value: '11' },
+					chainedKey: 'a:b:c:d:1',
+				},
+				{
+					key: '2',
+					level: 5,
+					value: { value: '22' },
+					chainedKey: 'a:b:c:d:2',
+				},
+				{
+					key: '3',
+					level: 5,
+					value: { value: '33' },
+					chainedKey: 'a:b:c:d:3',
+				},
+				{
+					key: 'e',
+					level: 5,
+					value: { value: '50' },
+					chainedKey: 'a:b:c:d:e',
+				},
+				{
+					key: '4',
+					level: 6,
+					value: { value: '44' },
+					chainedKey: 'a:b:c:d:3:4',
+				},
+				{
+					key: 'f',
+					level: 6,
+					value: { value: '60' },
+					chainedKey: 'a:b:c:d:e:f',
+				},
 			]);
 		});
 	});


### PR DESCRIPTION
Supporting value versioning on the storage will provide the ability for the repository to have multiple versions of the same key, giving a chance for the ttl of an old value, that you want to lose influence to be expired.
The idea is:

* During persistence, the storage will only add/update values in the newest version;
*  During query, the storage will return all the versions (or the N-latest, which fits the use case the most), so the final value can be a combination of those;

To use this approach, the value serializer must implement the method **deserializeList**, which will be in charge of transforming a list of serialized values into the desired entity. For example, if the desired entity is a number, the resulting value can be the average of the received list.


Some use cases for this technique:
* To calculate the average of the last 5 minutes of results of a health check;
* To get the percentile of the last 7 days of a given value;


All of these, of course, taking advantage of the tree structure that the library offers.