### PR TITLE
feat: creating memory tree deep-tree-set

### DIFF
--- a/src/utils/deep-tree-set.ts
+++ b/src/utils/deep-tree-set.ts
@@ -1,0 +1,48 @@
+import { ChainedObject, Step, Tree, TreeKeys } from 'src/types';
+
+class StepRef<T> implements Step<T> {
+	constructor(
+		private treeRef: Tree<T>,
+		public key: string,
+		public level: number,
+		public nodeRef: ChainedObject,
+	) {}
+
+	get value(): T | undefined {
+		return this.treeRef[TreeKeys.value];
+	}
+	set value(newValue: T | undefined) {
+		this.treeRef[TreeKeys.value] = newValue;
+	}
+}
+
+/**
+ * Set the value for the specified path in the sync tree in memory, calling
+ * createValue for each node on the way
+ * and yielding each step, allowing edition
+ * @param tree Tree to
+ * @param path the path to set
+ * @param createValue callback to create non existing values
+ */
+export function* deepTreeSet<T>(
+	tree: Tree<T>,
+	path: string[],
+	createValue?: (level: number) => T | undefined,
+): Iterable<Step<T>> {
+	let level = 0;
+	let nodeRef: ChainedObject | undefined;
+	for (const key of path) {
+		level++;
+		tree[TreeKeys.children] ??= {};
+		const newTree = (tree[TreeKeys.children][key] ??= {
+			[TreeKeys.value]: createValue?.(level),
+		});
+		nodeRef = {
+			key,
+			level,
+			parentRef: nodeRef,
+		};
+		yield new StepRef(newTree, key, level, nodeRef);
+		tree = newTree;
+	}
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './build-key';
+export * from './deep-tree-set';
 export * from './deserialize-whole-tree';
 export * from './dont-wait';

--- a/test/unit/utils/deep-tree-set.spec.ts
+++ b/test/unit/utils/deep-tree-set.spec.ts
@@ -1,0 +1,65 @@
+import { Tree, TreeKeys, deepTreeSet } from 'src/index';
+
+describe(deepTreeSet.name, () => {
+	it('should set and yield the node steps, accepting step editing', () => {
+		const tree: Tree<number> = {
+			[TreeKeys.children]: {
+				a: {
+					[TreeKeys.value]: 1,
+					[TreeKeys.children]: {
+						b: {
+							[TreeKeys.value]: 2,
+						},
+						c: {
+							[TreeKeys.value]: 3,
+							[TreeKeys.children]: {
+								d: {
+									[TreeKeys.value]: 4,
+								},
+								e: {
+									[TreeKeys.value]: 5,
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const iterable = deepTreeSet(tree, ['a', 'c', 'e', 'f'], () => 0);
+		for (const step of iterable) {
+			if (step.value !== undefined && step.value !== 4) {
+				step.value++;
+			}
+		}
+
+		expect(tree).toEqual({
+			[TreeKeys.children]: {
+				a: {
+					[TreeKeys.value]: 2,
+					[TreeKeys.children]: {
+						b: {
+							[TreeKeys.value]: 2,
+						},
+						c: {
+							[TreeKeys.value]: 4,
+							[TreeKeys.children]: {
+								d: {
+									[TreeKeys.value]: 4,
+								},
+								e: {
+									[TreeKeys.value]: 6,
+									[TreeKeys.children]: {
+										f: {
+											[TreeKeys.value]: 1,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+	});
+});


### PR DESCRIPTION
The idea here is to create an in-memory tree with a lot of accumulated operations, to be set once using fullTreeSet. This is useful to avoid generating lots of IO with the external database, but it ends up needing the use of semaphore in concurrency cases, as collisions may cause more serious issues.