### PR TITLE
fix: fixing full tree set saving

### DIFF
--- a/test/unit/tree-key-cache-fullTreeSet.spec.ts
+++ b/test/unit/tree-key-cache-fullTreeSet.spec.ts
@@ -49,6 +49,22 @@ describe(TreeKeyCache.name, () => {
 															},
 														},
 													},
+													e2: {
+														v: { value: 50 },
+														[TreeKeys.children]: {
+															f: {
+																v: { value: 61 },
+															},
+														},
+													},
+													e3: {
+														v: { value: 50 },
+														[TreeKeys.children]: {
+															f: {
+																v: { value: 61 },
+															},
+														},
+													},
 												},
 											},
 										},
@@ -83,6 +99,18 @@ describe(TreeKeyCache.name, () => {
 							[TreeKeys.value]: '{"value":40}',
 							[TreeKeys.children]: {
 								e: {
+									v: '{"value":50}',
+									[TreeKeys.children]: {
+										f: { v: '{"value":61}' },
+									},
+								},
+								e3: {
+									v: '{"value":50}',
+									[TreeKeys.children]: {
+										f: { v: '{"value":61}' },
+									},
+								},
+								e2: {
 									v: '{"value":50}',
 									[TreeKeys.children]: {
 										f: { v: '{"value":61}' },


### PR DESCRIPTION
Full tree set was losing the tree trail when more than one child exists in some node.


To fix that, we've changed the algorithm so saveFullTreeSet, which saves tree level nodes, always lookup for the parent node to create the reference for the child one.

We also changed the unit test to validate some new value node with multiple children