### PR TITLE
feat: create multi tree select

### DIFF
--- a/src/internal/async-tree-ref.ts
+++ b/src/internal/async-tree-ref.ts
@@ -61,7 +61,10 @@ export class AsyncTreeRef<R> implements AsyncTree<R> {
 				const value = await get(buildKey(traversalItem));
 				if (level < this.options.keyLevelNodes) {
 					traversalItem[valueSymbol] = isAsyncIterable(value)
-						? await getMultiTreeValueFromAsyncIterable(value)
+						? await getMultiTreeValueFromAsyncIterable(
+								value,
+								this.options.multiTreeSelector,
+						  )
 						: value;
 					yield [
 						item,

--- a/src/internal/default-options.ts
+++ b/src/internal/default-options.ts
@@ -1,0 +1,16 @@
+import { fluentAsync } from '@codibre/fluent-iterable';
+import { DefaultOptions } from './options-types';
+
+const defaultSerializer = {
+	deserialize: JSON.parse.bind(JSON),
+	serialize: JSON.stringify.bind(JSON),
+};
+
+export const defaultOptions: DefaultOptions<unknown, unknown> = {
+	valueSerializer: defaultSerializer,
+	treeSerializer: defaultSerializer,
+	semaphore: {
+		acquire: async () => async () => undefined,
+	},
+	multiTreeSelector: (value) => fluentAsync(value).filter().toArray(),
+};

--- a/src/internal/get-multi-value-from-async-iterable.ts
+++ b/src/internal/get-multi-value-from-async-iterable.ts
@@ -1,4 +1,3 @@
-import { fluentAsync } from '@codibre/fluent-iterable';
 import { MultiTreeValue, multiTreeValue } from '../types';
 
 /**
@@ -8,8 +7,9 @@ import { MultiTreeValue, multiTreeValue } from '../types';
  */
 export async function getMultiTreeValueFromAsyncIterable<R>(
 	value: AsyncIterable<R | undefined>,
+	getMultiValue: (value: AsyncIterable<R | undefined>) => Promise<R[]>,
 ): Promise<MultiTreeValue<R>> {
 	return {
-		[multiTreeValue]: await fluentAsync(value).filter().toArray(),
+		[multiTreeValue]: await getMultiValue(value),
 	};
 }

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,4 +1,5 @@
 export * from './async-tree-ref';
+export * from './default-options';
 export * from './get-chained-key';
 export * from './get-key';
 export * from './get-multi-value-from-async-iterable';
@@ -8,9 +9,9 @@ export * from './get-next-tree-node';
 export * from './get-read-storage-function';
 export * from './get-tree-current-serialized-value';
 export * from './get-ttl';
-export * from './types';
 export * from './is-undefined';
 export * from './multi-tree-ref';
 export * from './options-types';
 export * from './prune-tree';
 export * from './tree-internal-control';
+export * from './types';

--- a/src/tree-key-cache.ts
+++ b/src/tree-key-cache.ts
@@ -32,7 +32,6 @@ import {
 	asyncTreePreOrderDepthFirstSearch,
 } from './utils/graphs/async';
 import {
-	DefaultOptions,
 	MergedOptions,
 	getNextTreeNode,
 	TreeInternalControl,
@@ -42,23 +41,10 @@ import {
 	getTtl,
 	isUndefinedOrNull,
 	getKey,
+	defaultOptions,
 } from './internal';
 import { constant, fluentAsync, fluentObject } from '@codibre/fluent-iterable';
 import { dontWait } from './utils';
-
-const defaultSerializer = {
-	deserialize: JSON.parse.bind(JSON),
-	serialize: JSON.stringify.bind(JSON),
-};
-
-const defaultOptions: DefaultOptions<unknown, unknown> = {
-	valueSerializer: defaultSerializer,
-	treeSerializer: defaultSerializer,
-	semaphore: {
-		acquire: async () => async () => undefined,
-	},
-};
-
 type Events = {
 	deserializeError(error: unknown, type: 'value' | 'tree'): void;
 };

--- a/src/types/key-tree-cache-options.ts
+++ b/src/types/key-tree-cache-options.ts
@@ -97,4 +97,11 @@ export interface KeyTreeCacheOptions<T, R = string> {
 	 * twice in the same memoizer context
 	 */
 	memoizer?: Memoizer;
+	/**
+	 * Select values from a multi tree to compose a new node.
+	 * Default is to get all values available
+	 * @param value the async iterable of values to be validated
+	 */
+
+	multiTreeSelector?: (value: AsyncIterable<R | undefined>) => Promise<R[]>;
 }


### PR DESCRIPTION
Introducing a method to give the chance for the user to determine which of the multi values of a node tree will be used. This is useful when we want to use just the N last values whenever they're considered good enough, for some arbitrary criteria